### PR TITLE
Event listeners for click tracking are registered when as24-tracking …

### DIFF
--- a/src/trackingElement.js
+++ b/src/trackingElement.js
@@ -4,7 +4,7 @@ var as24tracking = Object.assign(Object.create(HTMLElement.prototype), {
     supportedTypes: ['gtm', 'pagename'],
     reservedWords: ['type', 'action', 'as24-tracking-value', 'as24-tracking-click-target'],
 
-    createdCallback () {
+    attachedCallback () {
         var values = this.getAdditionalProperties();
         var type = this.getAttribute('type');
         var action = this.getAttribute('action');


### PR DESCRIPTION
…is attached to the dom and not when element is created

When using as24-tracking within client side fragments, the custom element as24-tracking is created dynamically and therefore the click listeners for click tracking should be registered when the custom element is attached to the dom and not when it is created. This currently causes a bug with the finance client side fragment on the detail page.