### PR TITLE
Update gtm-example.md

### DIFF
--- a/gtm-example.md
+++ b/gtm-example.md
@@ -51,7 +51,7 @@ function hasGoogleAdsConsent() {
       function (data, success) {
         consent = data;
       },
-      { data: { vendorId: 755 } }
+      { data: { vendorId: 10210 } }
     );
   } else if (window.__cmp && window.cmpEnabled) {
     window.__cmp('getVendorConsents', null, function (vendorConsents) {
@@ -60,8 +60,10 @@ function hasGoogleAdsConsent() {
           vendorConsents.purposeConsents[1] &&
           vendorConsents.purposeConsents[2] &&
           vendorConsents.purposeConsents[3] &&
-          vendorConsents.purposeConsents[5] &&
-          additionalVendorConsents.vendorConsents[91];
+          vendorConsents.purposeConsents[4] &&
+          vendorConsents.purposeConsents[7] &&
+          vendorConsents.purposeConsents[9] &&
+          vendorConsents.purposeConsents[10];
       });
     });
   } else {


### PR DESCRIPTION
Updated Google Ads Vendor ID and purpose consents: This is correct for Perf. Marketing according to Laura and we will not worry about Media, since Media does not have a single Google Ads Tags in GTM. SO from a GTM perspective we are fine. We need to block only Google Ads - Perf. Marketing side.