### PR TITLE
Delete consent query params after using them

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -51,6 +51,16 @@
                 document.cookie = ['gdpr-last-interaction=' + gdprLastInteraction, path, maxAge, domain, sameSite].join(
                     ';'
                 );
+
+                // We need to delete consent params from the URL
+                // so that they don't corrupt GA tracking and other tools.
+                urlParams.delete('euconsent-v2');
+                urlParams.delete('cconsent-v2');
+                urlParams.delete('gdpr-auditId');
+                urlParams.delete('addtl_consent');
+                urlParams.delete('gdpr-last-interaction');
+
+                history.replaceState(null, '', `?${urlParams.toString()}`);
             }
         }
 

--- a/dist/test.html
+++ b/dist/test.html
@@ -594,6 +594,16 @@
                             domain,
                             sameSite,
                         ].join(';');
+
+                        // We need to delete consent params from the URL
+                        // so that they don't corrupt GA tracking and other tools.
+                        urlParams.delete('euconsent-v2');
+                        urlParams.delete('cconsent-v2');
+                        urlParams.delete('gdpr-auditId');
+                        urlParams.delete('addtl_consent');
+                        urlParams.delete('gdpr-last-interaction');
+
+                        history.replaceState(null, '', `?${urlParams.toString()}`);
                     }
                 }
 


### PR DESCRIPTION
We want to avoid the URL becoming too long and with that corrupting other tracking (e.g. GA).

See also: https://github.com/AutoScout24/showcar-react/pull/383