### PR TITLE
[SEE-1675] preparations for load the new cmp script and banner

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -148,6 +148,67 @@
             });
         }
 
+        function loadAs24Cmp() {
+            return new Promise(resolve => {
+                var script = document.createElement('script');
+                var ref = document.getElementsByTagName('script')[0];
+                ref.parentNode.insertBefore(script, ref);
+                var culture = getCulture(window.location.hostname, window.location.pathname);
+                script.src = 'https://www.autoscout24.com/assets/as24-cmp/consent-banner/' + culture + '.js';
+
+                resolve();
+            });
+        }
+
+        function getCulture(hostname, path) {
+            const tld = hostname.split('.').pop();
+            
+            switch (tld) {
+                case 'de':
+                    return 'de-DE';
+                case 'at':
+                    return 'de-AT';
+                case 'it':
+                    return 'it-IT';
+                case 'es':
+                    return 'es-ES';
+                case 'fr':
+                    return 'fr-FR';
+                case 'nl':
+                    return 'nl-NL';
+                case 'lu':
+                    return 'fr-LU';
+                case 'com':
+                    return 'en-GB';
+                case 'bg':
+                    return 'bg-BG';
+                case 'hu':
+                    return 'hu-HU';
+                case 'pl':
+                    return 'pl-PL';
+                case 'ro':
+                    return 'ro-RO';
+                case 'hr':
+                    return 'hr-HR';
+                case 'cz':
+                    return 'cs-CZ';
+                case 'ua':
+                    return 'uk-UA';
+                case 'se':
+                    return 'sv-SE';
+                case 'ru':
+                    return 'ru-RU';
+                case 'tr':
+                    return 'tr-TR';     
+                case 'be':
+                    return path.startsWith('/nl/') ? 'nl-BE' : 'fr-BE';
+                case 'localhost':
+                case 'tech':
+                default:
+                    return 'en-GB';
+            }
+        }
+
         function loadLiveRampScript(uid) {
             var script = document.createElement('script');
             var ref = document.getElementsByTagName('script')[0];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,13 +13,20 @@
         // prettier-ignore
         !function(e){var t={};function n(r){if(t[r])return t[r].exports;var a=t[r]={i:r,l:!1,exports:{}};return e[r].call(a.exports,a,a.exports,n),a.l=!0,a.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var a in e)n.d(r,a,function(t){return e[t]}.bind(null,a));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p="https://gdpr.privacymanager.io/1.0.10/",n(n.s=38)}({38:function(e,t){!function(){if("function"!=typeof window.__tcfapi){var e,t=[],n=window,r=n.document,a=n.__tcfapi?n.__tcfapi.start:function(){};!n.__tcfapi&&function e(){var t=!!n.frames.__tcfapiLocator;if(!t)if(r.body){var a=r.createElement("iframe");a.style.cssText="display:none",a.name="__tcfapiLocator",r.body.appendChild(a)}else setTimeout(e,5);return!t}()&&(n.__tcfapi=function(n,r,a,o){var i=[n,r,a,o];if(!i.length)return t;if("setGdprApplies"===i[0])i.length>3&&2===parseInt(i[1],10)&&"boolean"==typeof i[3]&&(e=i[3],"function"==typeof i[2]&&i[2]("set",!0));else if("ping"===i[0]){var c={gdprApplies:e,cmpLoaded:!1,apiVersion:"2.0"};"function"==typeof i[2]&&i[2](c,!0)}else t.push(i)},n.__tcfapi.commandQueue=t,n.__tcfapi.start=a,n.addEventListener("message",(function(e){var t="string"==typeof e.data,r={};try{r=t?JSON.parse(e.data):e.data}catch(e){}var a=r.__tcfapiCall;a&&n.__tcfapi(a.command,a.version,(function(n,r){if(e.source){var o={__tcfapiReturn:{returnValue:n,success:r,callId:a.callId,command:a.command}};t&&(o=JSON.stringify(o)),e.source.postMessage(o,"*")}}),a.parameter)}),!1))}}()}});
 
-        var tld = window.location.hostname.split('.').pop();
 
-        setCmpLanguage(tld, window.location.pathname);
-        hideCmpIfNeeded();
-        trackCmpEvents();
-        loadCmpWithoutAbTest();
-        deletePersonalizationCookiesIfNeeded()
+        loadAs24Cmp().then(() => {
+            if (window.__as24CmpEnabled) {
+                return;
+            }
+            
+            var tld = window.location.hostname.split('.').pop();
+
+            setCmpLanguage(tld, window.location.pathname);
+            hideCmpIfNeeded();
+            trackCmpEvents();
+            loadCmpWithoutAbTest();
+            deletePersonalizationCookiesIfNeeded()
+        });
 
         /** In case we don't have a visitor id we set one. */
         function ensureVisitorId() {

--- a/dist/test.html
+++ b/dist/test.html
@@ -552,6 +552,19 @@
                 // prettier-ignore
                 !function(e){var t={};function n(r){if(t[r])return t[r].exports;var a=t[r]={i:r,l:!1,exports:{}};return e[r].call(a.exports,a,a.exports,n),a.l=!0,a.exports}n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var a in e)n.d(r,a,function(t){return e[t]}.bind(null,a));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p="https://gdpr.privacymanager.io/1.0.10/",n(n.s=38)}({38:function(e,t){!function(){if("function"!=typeof window.__tcfapi){var e,t=[],n=window,r=n.document,a=n.__tcfapi?n.__tcfapi.start:function(){};!n.__tcfapi&&function e(){var t=!!n.frames.__tcfapiLocator;if(!t)if(r.body){var a=r.createElement("iframe");a.style.cssText="display:none",a.name="__tcfapiLocator",r.body.appendChild(a)}else setTimeout(e,5);return!t}()&&(n.__tcfapi=function(n,r,a,o){var i=[n,r,a,o];if(!i.length)return t;if("setGdprApplies"===i[0])i.length>3&&2===parseInt(i[1],10)&&"boolean"==typeof i[3]&&(e=i[3],"function"==typeof i[2]&&i[2]("set",!0));else if("ping"===i[0]){var c={gdprApplies:e,cmpLoaded:!1,apiVersion:"2.0"};"function"==typeof i[2]&&i[2](c,!0)}else t.push(i)},n.__tcfapi.commandQueue=t,n.__tcfapi.start=a,n.addEventListener("message",(function(e){var t="string"==typeof e.data,r={};try{r=t?JSON.parse(e.data):e.data}catch(e){}var a=r.__tcfapiCall;a&&n.__tcfapi(a.command,a.version,(function(n,r){if(e.source){var o={__tcfapiReturn:{returnValue:n,success:r,callId:a.callId,command:a.command}};t&&(o=JSON.stringify(o)),e.source.postMessage(o,"*")}}),a.parameter)}),!1))}}()}});
 
+                loadAs24Cmp().then(() => {
+                    if (window.__as24CmpEnabled) {
+                        return;
+                    }
+
+                    var tld = window.location.hostname.split('.').pop();
+                    setCmpLanguage(tld, window.location.pathname);
+                    hideCmpIfNeeded();
+                    trackCmpEvents();
+                    loadCmpWithoutAbTest();
+                    deletePersonalizationCookiesIfNeeded();
+                });
+
                 var tld = window.location.hostname.split('.').pop();
 
                 setCmpLanguage(tld, window.location.pathname);
@@ -689,6 +702,68 @@
                             event
                         );
                     });
+                }
+
+                
+                function loadAs24Cmp() {
+                    return new Promise(resolve => {
+                        var script = document.createElement('script');
+                        var ref = document.getElementsByTagName('script')[0];
+                        ref.parentNode.insertBefore(script, ref);
+                        var culture = getCulture(window.location.hostname, window.location.pathname);
+                        script.src = 'https://www.autoscout24.com/assets/as24-cmp/consent-banner/' + culture + '.js';
+
+                        resolve();
+                    });
+                }
+
+                function getCulture(hostname, path) {
+                    const tld = hostname.split('.').pop();
+                    
+                    switch (tld) {
+                        case 'de':
+                            return 'de-DE';
+                        case 'at':
+                            return 'de-AT';
+                        case 'it':
+                            return 'it-IT';
+                        case 'es':
+                            return 'es-ES';
+                        case 'fr':
+                            return 'fr-FR';
+                        case 'nl':
+                            return 'nl-NL';
+                        case 'lu':
+                            return 'fr-LU';
+                        case 'com':
+                            return 'en-GB';
+                        case 'bg':
+                            return 'bg-BG';
+                        case 'hu':
+                            return 'hu-HU';
+                        case 'pl':
+                            return 'pl-PL';
+                        case 'ro':
+                            return 'ro-RO';
+                        case 'hr':
+                            return 'hr-HR';
+                        case 'cz':
+                            return 'cs-CZ';
+                        case 'ua':
+                            return 'uk-UA';
+                        case 'se':
+                            return 'sv-SE';
+                        case 'ru':
+                            return 'ru-RU';
+                        case 'tr':
+                            return 'tr-TR';     
+                        case 'be':
+                            return path.startsWith('/nl/') ? 'nl-BE' : 'fr-BE';
+                        case 'localhost':
+                        case 'tech':
+                        default:
+                            return 'en-GB';
+                    }
                 }
 
                 function loadLiveRampScript(uid) {

--- a/src/cashstack.js
+++ b/src/cashstack.js
@@ -12,12 +12,18 @@
     // prettier-ignore
     !function (e) { var t = {}; function n(r) { if (t[r]) return t[r].exports; var a = t[r] = { i: r, l: !1, exports: {} }; return e[r].call(a.exports, a, a.exports, n), a.l = !0, a.exports } n.m = e, n.c = t, n.d = function (e, t, r) { n.o(e, t) || Object.defineProperty(e, t, { enumerable: !0, get: r }) }, n.r = function (e) { "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }), Object.defineProperty(e, "__esModule", { value: !0 }) }, n.t = function (e, t) { if (1 & t && (e = n(e)), 8 & t) return e; if (4 & t && "object" == typeof e && e && e.__esModule) return e; var r = Object.create(null); if (n.r(r), Object.defineProperty(r, "default", { enumerable: !0, value: e }), 2 & t && "string" != typeof e) for (var a in e) n.d(r, a, function (t) { return e[t] }.bind(null, a)); return r }, n.n = function (e) { var t = e && e.__esModule ? function () { return e.default } : function () { return e }; return n.d(t, "a", t), t }, n.o = function (e, t) { return Object.prototype.hasOwnProperty.call(e, t) }, n.p = "https://gdpr.privacymanager.io/1.0.10/", n(n.s = 38) }({ 38: function (e, t) { !function () { if ("function" != typeof window.__tcfapi) { var e, t = [], n = window, r = n.document, a = n.__tcfapi ? n.__tcfapi.start : function () { }; !n.__tcfapi && function e() { var t = !!n.frames.__tcfapiLocator; if (!t) if (r.body) { var a = r.createElement("iframe"); a.style.cssText = "display:none", a.name = "__tcfapiLocator", r.body.appendChild(a) } else setTimeout(e, 5); return !t }() && (n.__tcfapi = function (n, r, a, o) { var i = [n, r, a, o]; if (!i.length) return t; if ("setGdprApplies" === i[0]) i.length > 3 && 2 === parseInt(i[1], 10) && "boolean" == typeof i[3] && (e = i[3], "function" == typeof i[2] && i[2]("set", !0)); else if ("ping" === i[0]) { var c = { gdprApplies: e, cmpLoaded: !1, apiVersion: "2.0" }; "function" == typeof i[2] && i[2](c, !0) } else t.push(i) }, n.__tcfapi.commandQueue = t, n.__tcfapi.start = a, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, r = {}; try { r = t ? JSON.parse(e.data) : e.data } catch (e) { } var a = r.__tcfapiCall; a && n.__tcfapi(a.command, a.version, (function (n, r) { if (e.source) { var o = { __tcfapiReturn: { returnValue: n, success: r, callId: a.callId, command: a.command } }; t && (o = JSON.stringify(o)), e.source.postMessage(o, "*") } }), a.parameter) }), !1)) } }() } });
 
-    var tld = window.location.hostname.split('.').pop();
+    loadAs24Cmp().then(() => {
+        if (window.__as24CmpEnabled) {
+            return;
+        }
 
-    setCmpLanguage(tld, window.location.pathname);
-    hideCmpIfNeeded();
-    trackCmpEvents();
-    loadCmpWithoutAbTest();
+        var tld = window.location.hostname.split('.').pop();
+
+        setCmpLanguage(tld, window.location.pathname);
+        hideCmpIfNeeded();
+        trackCmpEvents();
+        loadCmpWithoutAbTest();
+    });
 
     // if (tld === 'it') {
     //     loadCmpWithAbTest();
@@ -140,6 +146,67 @@
                 event
             );
         });
+    }
+
+    function loadAs24Cmp() {
+        return new Promise(resolve => {
+            var script = document.createElement('script');
+            var ref = document.getElementsByTagName('script')[0];
+            ref.parentNode.insertBefore(script, ref);
+            var culture = getCulture(window.location.hostname, window.location.pathname);
+            script.src = 'https://www.autoscout24.com/assets/as24-cmp/consent-banner/' + culture + '.js';
+
+            resolve();
+        });
+    }
+
+    function getCulture(hostname, path) {
+        const tld = hostname.split('.').pop();
+        
+        switch (tld) {
+            case 'de':
+                return 'de-DE';
+            case 'at':
+                return 'de-AT';
+            case 'it':
+                return 'it-IT';
+            case 'es':
+                return 'es-ES';
+            case 'fr':
+                return 'fr-FR';
+            case 'nl':
+                return 'nl-NL';
+            case 'lu':
+                return 'fr-LU';
+            case 'com':
+                return 'en-GB';
+            case 'bg':
+                return 'bg-BG';
+            case 'hu':
+                return 'hu-HU';
+            case 'pl':
+                return 'pl-PL';
+            case 'ro':
+                return 'ro-RO';
+            case 'hr':
+                return 'hr-HR';
+            case 'cz':
+                return 'cs-CZ';
+            case 'ua':
+                return 'uk-UA';
+            case 'se':
+                return 'sv-SE';
+            case 'ru':
+                return 'ru-RU';
+            case 'tr':
+                return 'tr-TR';     
+            case 'be':
+                return path.startsWith('/nl/') ? 'nl-BE' : 'fr-BE';
+            case 'localhost':
+            case 'tech':
+            default:
+                return 'en-GB';
+        }
     }
 
     function loadLiveRampScript(uid) {


### PR DESCRIPTION
- This PR contains adjustments to prepare the new cmp live roll out. 
The idea is to have a async method called `loadAs24Cmp` to load the new native cmp script first and depending on the state of the global variable `window.__as24CmpEnabled`, decide whether to show the new consent banner or fall back to the old way by loading the script from live ramp and showing the respective banner.

https://user-images.githubusercontent.com/11267701/199681030-8e34775e-8adb-451d-96cb-eb7b23a8cf61.mov

