### PR TITLE
hide CMP on /entryy/logout page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -237,8 +237,10 @@
             var isOnDealerInfoPages = /^\/(haendler|nl\/verkopers|(fr\/)?professional|autobedrijven|garages|profesionales|concessionari|((fr|nl)\/)?dealerinfo\/admin)/.test(
                 window.location.pathname
             );
+            var isEntryLogoutPage = /^\/(entry)/.test(window.location.pathname);
 
             var shouldHideCmp =
+                isEntryLogoutPage || // on entry logout page
                 window.location.hostname === 'accounts.autoscout24.com' || // on Identity pages
                 isOnPrivacyPage || // on privacy pages
                 isOnDealerInfoPages ||


### PR DESCRIPTION
On the `/entry/logout` page in .de we were showing the CMP. This PR hides the CMP banner on all `/entry/*` pages.

Seems the regex is working as expected :)

<img width="403" alt="Screenshot 2022-12-19 at 20 28 01" src="https://user-images.githubusercontent.com/11267701/208504542-9002952a-931d-4c28-9f39-20435e59492b.png">
